### PR TITLE
Added an Storage abstraction layer

### DIFF
--- a/Examples/ConsoleApp/FileBotStorage.cs
+++ b/Examples/ConsoleApp/FileBotStorage.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using System.Threading.Tasks;
+using WTelegram;
+
+namespace ConsoleApp;
+internal class FileBotStorage(string directory) : IBotStorage
+{
+    public Bot.State? State { get; private set; }
+    public string DataSource { get; } = $"File Directory: {directory}";
+    public string StorageDirectory { get; } = directory;
+
+    public void Dispose() { }
+
+    public void GetTables(out IBotStorage.ISetCache<WTelegram.Types.User> users, out IBotStorage.ISetCache<WTelegram.Types.Chat> chats)
+    {
+        Directory.CreateDirectory(StorageDirectory);
+        users = new FileSet<WTelegram.Types.User>(this);
+        chats = new FileSet<WTelegram.Types.Chat>(this);
+    }
+
+    public Dictionary<long, UpdateManager.MBoxState> LoadMBoxStates()
+    {
+        Directory.CreateDirectory(StorageDirectory);
+        var f = Path.Combine(StorageDirectory, "mbox.json");
+        if (File.Exists(f))
+        {
+            using var stream = File.OpenRead(f);
+            return JsonSerializer.Deserialize<Dictionary<long, UpdateManager.MBoxState>>(stream)!;
+        }
+        return [];
+    }
+
+    public Stream LoadSessionState()
+    {
+        Debug.Assert(State is not null);
+        Directory.CreateDirectory(StorageDirectory);
+        var f = Path.Combine(StorageDirectory, "session");
+        using var stream = File.Open(f, FileMode.OpenOrCreate);
+        Bot.StateBuffer buffer;
+        try
+        {
+            buffer = JsonSerializer.Deserialize<Bot.StateBuffer>(stream);
+        }
+        catch (JsonException)
+        {
+            buffer = Bot.StateBuffer.Empty;
+        }
+
+        State.LoadState(buffer);
+        return State.CreateSessionStoreStream(SaveSessionState);
+    }
+
+    public record struct TLUpdateBuffer(int Id, TL.Update Update)
+    {
+        public static implicit operator (int id, TL.Update update)(TLUpdateBuffer buffer)
+            => (buffer.Id, buffer.Update);
+
+        public (int id, TL.Update update) ToTuple()
+            => (Id, Update);
+    }
+
+    public IEnumerable<(int id, TL.Update update)> LoadTLUpdates()
+    {
+        Directory.CreateDirectory(StorageDirectory);
+        var f = Path.Combine(StorageDirectory, "updates.json");
+        if (File.Exists(f))
+        {
+            using var stream = File.OpenRead(f);
+            return JsonSerializer.Deserialize<IEnumerable<TLUpdateBuffer>>(stream)!.Select(x => x.ToTuple());
+        }
+        return [];
+    }
+
+    public void SaveMBoxStates(IReadOnlyDictionary<long, UpdateManager.MBoxState> state)
+    {
+        Directory.CreateDirectory(StorageDirectory);
+        var f = Path.Combine(StorageDirectory, "mbox.json");
+        using var stream = File.Open(f, FileMode.Create);
+        JsonSerializer.Serialize(stream, state);
+    }
+
+    public void SaveSessionState(byte[]? sessionData = null)
+    {
+        Directory.CreateDirectory(StorageDirectory);
+        var f = Path.Combine(StorageDirectory, "session");
+        var sess = sessionData ?? State?.SessionDataMemory;
+        if (sess is not ReadOnlyMemory<byte> toWrite)
+        {
+            if (File.Exists(f))
+                File.Delete(f);
+            return;
+        }
+
+        using var stream = File.Open(f, FileMode.Create);
+        var span = toWrite.Span;
+        for (int i = 0; i < span.Length; i++)
+            stream.WriteByte(span[i]);
+    }
+
+    public void SaveTLUpdates(IEnumerable<WTelegram.Types.Update> updates)
+    {
+        Directory.CreateDirectory(StorageDirectory);
+        var f = Path.Combine(StorageDirectory, "updates.json");
+        using var stream = File.Open(f, FileMode.Create);
+        JsonSerializer.Serialize(stream, updates.Select(x => new TLUpdateBuffer(x.Id, x.TLUpdate!)));
+    }
+
+    public void AssignBotState(Bot.State state)
+    {
+        if (State is not null)
+            throw new InvalidOperationException($"Cannot assign the Bot.State to this storage more than once");
+        State = state;
+    }
+
+    public class FileSet<T> : IBotStorage.ISetCache<T>
+        where T : class
+    {
+        private readonly Dictionary<long, T> cache = [];
+        private readonly FileBotStorage storage;
+        private readonly string dir;
+        internal FileSet(FileBotStorage storage) 
+        { 
+            this.storage = storage;
+            dir = Path.Combine(storage.StorageDirectory, typeof(T).FullName!);
+        }
+
+        public string GetFilePathFor(long key)
+        {
+            Directory.CreateDirectory(dir);
+            return Path.Combine(dir, $"{key}.json");
+        }
+
+        public T this[long key]
+        {
+            set
+            {
+                Directory.CreateDirectory(dir);
+                var f = GetFilePathFor(key);
+                using var stream = File.Open(f, FileMode.Create);
+                cache[key] = value;
+                JsonSerializer.Serialize<T>(stream, value);
+            }
+        }
+
+        public bool TryGetValue(long key, [MaybeNullWhen(false)] out T value)
+        {
+            if (cache.TryGetValue(key, out value))
+                return true;
+
+            var f = GetFilePathFor(key);
+            if (File.Exists(f))
+            {
+                using var stream = File.Open(f, FileMode.Create);
+                value = JsonSerializer.Deserialize<T>(stream)!;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+
+        public void ClearCache()
+        {
+            cache.Clear();
+        }
+
+        public T? SearchCache(Predicate<T> predicate)
+        {
+            foreach (var value in cache.Values)
+                if (predicate(value)) return value;
+
+            return null;
+        }
+    }
+}

--- a/Examples/ConsoleApp/Program.cs
+++ b/Examples/ConsoleApp/Program.cs
@@ -1,6 +1,7 @@
 ﻿// ----------------------------------------------------------------------------------------------
 // This example demonstrates a lot of things you cannot normally do with Telegram.Bot / Bot API
 // ----------------------------------------------------------------------------------------------
+using ConsoleApp;
 using System.Text;
 using Telegram.Bot;
 using Telegram.Bot.Types;
@@ -8,9 +9,9 @@ using Telegram.Bot.Types.Enums;
 
 // This code needs these 3 variables in Project Properties > Debug > Launch Profiles > Environment variables
 // Get your Api Id/Hash from https://my.telegram.org/apps
-int apiId = int.Parse(Environment.GetEnvironmentVariable("ApiId")!);
-string apiHash = Environment.GetEnvironmentVariable("ApiHash")!;
-string botToken = Environment.GetEnvironmentVariable("BotToken")!;
+int apiId = 24607747;
+string apiHash = "1a49eb4b8935d780fa7c54c85e786838";
+string botToken = "7788578706:AAF2OYkxbpKV_0ccmeqbU5rsghpbNPLyT_k";
 
 StreamWriter WTelegramLogs = new StreamWriter("WTelegramBot.log", true, Encoding.UTF8) { AutoFlush = true };
 WTelegram.Helpers.Log = (lvl, str) => WTelegramLogs.WriteLine($"{DateTime.Now:yyyy-MM-dd HH:mm:ss} [{"TDIWE!"[lvl]}] {str}");
@@ -20,6 +21,7 @@ using var connection = new Microsoft.Data.Sqlite.SqliteConnection(@"Data Source=
 //SQL Server:	using var connection = new Microsoft.Data.SqlClient.SqlConnection(@"Data Source=(LocalDB)\MSSQLLocalDB;AttachDbFilename=PATH_TO.mdf;Integrated Security=True;Connect Timeout=60");
 //MySQL:    	using var connection = new MySql.Data.MySqlClient.MySqlConnection(@"Data Source=...");
 //PosgreSQL:	using var connection = new Npgsql.NpgsqlConnection(@"Data Source=...");
+//Local File Storage: var storage = new FileBotStorage(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "WTelegramBot", "ConsoleAppExample"));
 
 using var bot = new WTelegram.Bot(botToken, apiId, apiHash, connection);
 //          use new WTelegramBotClient(...) instead, if you want the power of WTelegram with Telegram.Bot compatibility for existing code

--- a/src/Database.cs
+++ b/src/Database.cs
@@ -1,249 +1,233 @@
 ﻿using System.Data.Common;
+using System.Diagnostics;
+using Telegram.Bot;
 using TL;
+using TL.Methods;
 using Chat = WTelegram.Types.Chat;
 using Update = WTelegram.Types.Update;
 using User = WTelegram.Types.User;
 
 namespace WTelegram;
 
-internal partial class Database : IDisposable
+internal partial class Database : IDisposable, IBotStorage
 {
-	private readonly DbConnection _connection;
-	private readonly DbCommand[] _cmd = new DbCommand[DefaultSqlCommands[0].Length];
-	private readonly Bot.State _state;
+    private readonly DbConnection _connection;
+    private readonly DbCommand[] _cmd = new DbCommand[DefaultSqlCommands[0].Length];
+    private Bot.State? _state;
 
-	public Database(DbConnection connection, string[] sqlCommands, Bot.State state)
-	{
-		if (sqlCommands.Length != DefaultSqlCommands[0].Length)
-			throw new ArgumentException($"Expected {DefaultSqlCommands[0].Length} SQL commands", nameof(sqlCommands));
-		_connection = connection;
-		_state = state;
-		for (int i = 0; i < sqlCommands.Length; i++)
-		{
-			var command = _cmd[i] = _connection.CreateCommand();
-			command.CommandText = sqlCommands[i];
-			string defCmd = DefaultSqlCommands[0][i];
-			for (int at = 0; (at = defCmd.IndexOf('@', at + 1)) > 0;)
-			{
-				var end = defCmd.IndexOfAny([',', ' ', ')', ';'], at + 1);
-				var param = command.CreateParameter();
-				param.ParameterName = defCmd[at..end];
-				if (!command.Parameters.Contains(param.ParameterName))
-					command.Parameters.Add(param);
-			}
-		}
-		connection.Open();
-		_cmd[DbSetup].ExecuteNonQuery();
-	}
+    public Bot.State? State => _state;
 
-	public void Dispose()
-	{
-		foreach (var cmd in _cmd) cmd.Dispose();
-		_connection.Dispose();
-	}
+    public string DataSource => _connection.DataSource;
 
-	internal Stream LoadSessionState()
-	{
-		using (var reader = _cmd[LoadSession].ExecuteReader())
-			if (reader.Read())
-			{
-				_state.SessionData = reader.GetValue(0) as byte[];
-				_state.LastUpdateId = reader.GetInt32(1);
-				_state.AllowedUpdates = reader.GetInt32(2);
-			}
-		return new SessionStore(_state.SessionData, SaveSessionState);
-	}
+    public void AssignBotState(Bot.State state)
+    {
+        lock (_cmd)
+        {
+            if (_state is not null)
+                throw new InvalidOperationException("Cannot change the Bot.State after it has been initially set");
+            _state = state;
+        }
+    }
 
-	internal void SaveSessionState(byte[]? sessionData = null)
-	{
-		if (sessionData != null) _state.SessionData = sessionData;
-		var cmd = _cmd[SaveSession];
-		cmd.Parameters[0].Value = _state.SessionData;
-		cmd.Parameters[1].Value = _state.LastUpdateId;
-		cmd.Parameters[2].Value = _state.AllowedUpdates;
-		cmd.ExecuteSave();
-	}
+    public Database(DbConnection connection, string[] sqlCommands)
+    {
+        if (sqlCommands.Length != DefaultSqlCommands[0].Length)
+            throw new ArgumentException($"Expected {DefaultSqlCommands[0].Length} SQL commands", nameof(sqlCommands));
+        _connection = connection;
+        for (int i = 0; i < sqlCommands.Length; i++)
+        {
+            var command = _cmd[i] = _connection.CreateCommand();
+            command.CommandText = sqlCommands[i];
+            string defCmd = DefaultSqlCommands[0][i];
+            for (int at = 0; (at = defCmd.IndexOf('@', at + 1)) > 0;)
+            {
+                var end = defCmd.IndexOfAny([',', ' ', ')', ';'], at + 1);
+                var param = command.CreateParameter();
+                param.ParameterName = defCmd[at..end];
+                if (!command.Parameters.Contains(param.ParameterName))
+                    command.Parameters.Add(param);
+            }
+        }
+        connection.Open();
+        _cmd[DbSetup].ExecuteNonQuery();
+    }
 
-	class SessionStore(byte[]? _data, Action<byte[]> save) : Stream
-	{
-		private int _dataLen = _data?.Length ?? 0;
-		private DateTime _lastWrite;
-		private Task? _delayedWrite;
+    public void Dispose()
+    {
+        foreach (var cmd in _cmd) cmd.Dispose();
+        _connection.Dispose();
+    }
 
-		protected override void Dispose(bool disposing) => _delayedWrite?.Wait();
+    public Stream LoadSessionState()
+    {
+        Debug.Assert(_state is not null);
+        using (var reader = _cmd[LoadSession].ExecuteReader())
+            if (reader.Read())
+            {
+                _state.SessionData = reader.GetValue(0) as byte[];
+                _state.LastUpdateId = reader.GetInt32(1);
+                _state.AllowedUpdates = reader.GetInt32(2);
+            }
+        return new IBotStorage.SessionStore(_state.SessionData, SaveSessionState);
+    }
 
-		public override int Read(byte[] buffer, int offset, int count)
-		{
-			Array.Copy(_data!, 0, buffer, offset, count);
-			return count;
-		}
+    public void SaveSessionState(byte[]? sessionData = null)
+    {
+        Debug.Assert(_state is not null);
+        if (sessionData != null) _state.SessionData = sessionData;
+        var cmd = _cmd[SaveSession];
+        cmd.Parameters[0].Value = _state.SessionData;
+        cmd.Parameters[1].Value = _state.LastUpdateId;
+        cmd.Parameters[2].Value = _state.AllowedUpdates;
+        cmd.ExecuteSave();
+    }
 
-		public override void Write(byte[] buffer, int offset, int count)
-		{
-			_data = buffer; _dataLen = count;
-			if (_delayedWrite != null) return;
-			var left = 1000 - (int)(DateTime.UtcNow - _lastWrite).TotalMilliseconds;
-			if (left < 0)
-			{
-				save(buffer[offset..(offset + count)]);
-				_lastWrite = DateTime.UtcNow;
-			}
-			else
-				_delayedWrite = Task.Delay(left).ContinueWith(t => { lock (this) { _delayedWrite = null; Write(_data, 0, _dataLen); } });
-		}
+    public IEnumerable<(int id, TL.Update update)> LoadTLUpdates()
+    {
+        using var reader = _cmd[LoadUpdates].ExecuteReader();
+        while (reader.Read())
+            using (var breader = new BinaryReader(reader.GetStream(1)))
+                yield return (reader.GetInt32(0), (TL.Update)breader.ReadTLObject(0));
+    }
 
-		public override long Length => _dataLen;
-		public override long Position { get => 0; set { } }
-		public override bool CanSeek => false;
-		public override bool CanRead => true;
-		public override bool CanWrite => true;
-		public override long Seek(long offset, SeekOrigin origin) => 0;
-		public override void SetLength(long value) { }
-		public override void Flush() { }
-	}
+    public void SaveTLUpdates(IEnumerable<Update> updates)
+    {
+        _cmd[DelUpdates].ExecuteNonQuery();
+        var cmd = _cmd[SaveUpdates];
+        using var memStream = new MemoryStream(1024);
+        foreach (var botUpdate in updates)
+        {
+            if (botUpdate.TLUpdate == null) continue;
+            memStream.SetLength(0);
+            using (var writer = new BinaryWriter(memStream, System.Text.Encoding.UTF8, leaveOpen: true))
+                botUpdate.TLUpdate.WriteTL(writer);
+            cmd.Parameters[0].Value = botUpdate.Id;
+            cmd.Parameters[1].Value = memStream.ToArray();
+            cmd.ExecuteNonQuery();
+        }
+    }
 
-	internal IEnumerable<(int id, TL.Update update)> LoadTLUpdates()
-	{
-		using var reader = _cmd[LoadUpdates].ExecuteReader();
-		while (reader.Read())
-			using (var breader = new BinaryReader(reader.GetStream(1)))
-				yield return (reader.GetInt32(0), (TL.Update)breader.ReadTLObject(0));
-	}
+    public Dictionary<long, UpdateManager.MBoxState> LoadMBoxStates()
+    {
+        using var reader = _cmd[LoadMBox].ExecuteReader();
+        var result = new Dictionary<long, UpdateManager.MBoxState>();
+        while (reader.Read())
+            result[reader.GetInt64(0)] = new() { pts = reader.GetInt32(1), access_hash = reader.GetInt64(2) };
+        return result;
+    }
 
-	internal void SaveTLUpdates(IEnumerable<Update> updates)
-	{
-		_cmd[DelUpdates].ExecuteNonQuery();
-		var cmd = _cmd[SaveUpdates];
-		using var memStream = new MemoryStream(1024);
-		foreach (var botUpdate in updates)
-		{
-			if (botUpdate.TLUpdate == null) continue;
-			memStream.SetLength(0);
-			using (var writer = new BinaryWriter(memStream, System.Text.Encoding.UTF8, leaveOpen: true))
-				botUpdate.TLUpdate.WriteTL(writer);
-			cmd.Parameters[0].Value = botUpdate.Id;
-			cmd.Parameters[1].Value = memStream.ToArray();
-			cmd.ExecuteNonQuery();
-		}
-	}
+    public void SaveMBoxStates(IReadOnlyDictionary<long, UpdateManager.MBoxState> state)
+    {
+        var cmd = _cmd[SaveMBox];
+        foreach (var mboxState in state)
+        {
+            cmd.Parameters[0].Value = mboxState.Key;
+            cmd.Parameters[1].Value = mboxState.Value.pts;
+            cmd.Parameters[2].Value = mboxState.Value.access_hash;
+            cmd.ExecuteNonQuery();
+        }
+    }
 
-	internal Dictionary<long, UpdateManager.MBoxState> LoadMBoxStates()
-	{
-		using var reader = _cmd[LoadMBox].ExecuteReader();
-		var result = new Dictionary<long, UpdateManager.MBoxState>();
-		while (reader.Read())
-			result[reader.GetInt64(0)] = new() { pts = reader.GetInt32(1), access_hash = reader.GetInt64(2) };
-		return result;
-	}
+    public void GetTables(out IBotStorage.ISetCache<User> users, out IBotStorage.ISetCache<Chat> chats)
+    {
+        users = new CachedTable<User>(DoLoadUser, DoSaveUser);
+        chats = new CachedTable<Chat>(DoLoadChat, DoSaveChat);
+    }
 
-	internal void SaveMBoxStates(IReadOnlyDictionary<long, UpdateManager.MBoxState> state)
-	{
-		var cmd = _cmd[SaveMBox];
-		foreach (var mboxState in state)
-		{
-			cmd.Parameters[0].Value = mboxState.Key;
-			cmd.Parameters[1].Value = mboxState.Value.pts;
-			cmd.Parameters[2].Value = mboxState.Value.access_hash;
-			cmd.ExecuteNonQuery();
-		}
-	}
-	
-	internal void GetTables(out CachedTable<User> users, out CachedTable<Chat> chats)
-	{
-		users = new CachedTable<User>(DoLoadUser, DoSaveUser);
-		chats = new CachedTable<Chat>(DoLoadChat, DoSaveChat);
-	}
+    private User? DoLoadUser(long id)
+    {
+        _cmd[LoadUser].Parameters[0].Value = id;
+        using var reader = _cmd[LoadUser].ExecuteReader();
+        if (!reader.Read()) return null;
+        var flags = reader.GetInt32(1);
+        return new User
+        {
+            Id = id,
+            AccessHash = reader.GetInt64(0),
+            FirstName = reader.GetString(2),
+            LastName = reader.GetString(3).NullIfEmpty(),
+            Username = reader.GetString(4).NullIfEmpty(),
+            LanguageCode = reader.GetString(5).NullIfEmpty(),
+            IsBot = (flags & 1) != 0,
+            IsPremium = (flags & 2) != 0,
+            AddedToAttachmentMenu = (flags & 4) != 0,
+            CanJoinGroups = (flags & 8) != 0,
+            CanReadAllGroupMessages = (flags & 16) != 0,
+            SupportsInlineQueries = (flags & 32) != 0,
+        };
+    }
 
-	private User? DoLoadUser(long id)
-	{
-		_cmd[LoadUser].Parameters[0].Value = id;
-		using var reader = _cmd[LoadUser].ExecuteReader();
-		if (!reader.Read()) return null;
-		var flags = reader.GetInt32(1);
-		return new User
-		{
-			Id = id,
-			AccessHash = reader.GetInt64(0),
-			FirstName = reader.GetString(2),
-			LastName = reader.GetString(3).NullIfEmpty(),
-			Username = reader.GetString(4).NullIfEmpty(),
-			LanguageCode = reader.GetString(5).NullIfEmpty(),
-			IsBot = (flags & 1) != 0, IsPremium = (flags & 2) != 0, AddedToAttachmentMenu = (flags & 4) != 0,
-			CanJoinGroups = (flags & 8) != 0, CanReadAllGroupMessages = (flags & 16) != 0, SupportsInlineQueries = (flags & 32) != 0,
-		};
-	}
+    private void DoSaveUser(User user)
+    {
+        var param = _cmd[SaveUser].Parameters;
+        param[0].Value = user.Id;
+        param[1].Value = user.AccessHash;
+        param[2].Value = (user.IsBot ? 1 : 0) | (user.IsPremium == true ? 2 : 0) | (user.AddedToAttachmentMenu == true ? 4 : 0)
+            | (user.CanJoinGroups == true ? 8 : 0) | (user.CanReadAllGroupMessages == true ? 16 : 0) | (user.SupportsInlineQueries == true ? 32 : 0);
+        param[3].Value = user.FirstName;
+        param[4].Value = user.LastName ?? "";
+        param[5].Value = user.Username ?? "";
+        param[6].Value = user.LanguageCode ?? "";
+        _cmd[SaveUser].ExecuteSave();
+    }
 
-	private void DoSaveUser(User user)
-	{
-		var param = _cmd[SaveUser].Parameters;
-		param[0].Value = user.Id;
-		param[1].Value = user.AccessHash;
-		param[2].Value = (user.IsBot ? 1 : 0) | (user.IsPremium == true ? 2 : 0) | (user.AddedToAttachmentMenu == true ? 4 : 0)
-			| (user.CanJoinGroups == true ? 8 : 0) | (user.CanReadAllGroupMessages == true ? 16 : 0) | (user.SupportsInlineQueries == true ? 32 : 0);
-		param[3].Value = user.FirstName;
-		param[4].Value = user.LastName ?? "";
-		param[5].Value = user.Username ?? "";
-		param[6].Value = user.LanguageCode ?? "";
-		_cmd[SaveUser].ExecuteSave();
-	}
+    private Chat? DoLoadChat(long id)
+    {
+        _cmd[LoadChat].Parameters[0].Value = id;
+        using var reader = _cmd[LoadChat].ExecuteReader();
+        if (!reader.Read()) return null;
+        var flags = reader.GetInt32(1);
+        var type = (ChatType)reader.GetInt32(5);
+        var firstName = reader.GetString(2);
+        return new Chat
+        {
+            Id = type == ChatType.Group ? -id : Bot.ZERO_CHANNEL_ID - id,
+            AccessHash = reader.GetInt64(0),
+            Type = type,
+            Title = type == ChatType.Private ? null : firstName,
+            FirstName = type == ChatType.Private ? firstName : null,
+            LastName = type == ChatType.Private ? reader.GetString(3).NullIfEmpty() : null,
+            Username = reader.GetString(4).NullIfEmpty(),
+            IsForum = (flags & 1) != 0,
+        };
+    }
 
-	private Chat? DoLoadChat(long id)
-	{
-		_cmd[LoadChat].Parameters[0].Value = id;
-		using var reader = _cmd[LoadChat].ExecuteReader();
-		if (!reader.Read()) return null;
-		var flags = reader.GetInt32(1);
-		var type = (ChatType)reader.GetInt32(5);
-		var firstName = reader.GetString(2);
-		return new Chat
-		{
-			Id = type == ChatType.Group ? -id : Bot.ZERO_CHANNEL_ID - id,
-			AccessHash = reader.GetInt64(0),
-			Type = type,
-			Title = type == ChatType.Private ? null : firstName,
-			FirstName = type == ChatType.Private ? firstName : null,
-			LastName = type == ChatType.Private ? reader.GetString(3).NullIfEmpty() : null,
-			Username = reader.GetString(4).NullIfEmpty(),
-			IsForum = (flags & 1) != 0,
-		};
-	}
+    private void DoSaveChat(Chat chat)
+    {
+        var param = _cmd[SaveChat].Parameters;
+        param[0].Value = chat.Id;
+        param[1].Value = chat.AccessHash;
+        param[2].Value = chat.IsForum == true ? 1 : 0;
+        param[3].Value = (chat.Type == ChatType.Private ? chat.FirstName : chat.Title) ?? "";
+        param[4].Value = chat.LastName ?? "";
+        param[5].Value = chat.Username ?? "";
+        param[6].Value = chat.Type;
+        _cmd[SaveChat].ExecuteSave();
+    }
 
-	private void DoSaveChat(Chat chat)
-	{
-		var param = _cmd[SaveChat].Parameters;
-		param[0].Value = chat.Id;
-		param[1].Value = chat.AccessHash;
-		param[2].Value = chat.IsForum == true ? 1 : 0;
-		param[3].Value = (chat.Type == ChatType.Private ? chat.FirstName : chat.Title) ?? "";
-		param[4].Value = chat.LastName ?? "";
-		param[5].Value = chat.Username ?? "";
-		param[6].Value = chat.Type;
-		_cmd[SaveChat].ExecuteSave();
-	}
+    internal class CachedTable<T>(Func<long, T?> load, Action<T> save) : IBotStorage.ISetCache<T> where T : class
+    {
+        private readonly Dictionary<long, T> _cache = [];
 
-	internal class CachedTable<T>(Func<long, T?> load, Action<T> save) where T : class
-	{
-		private readonly Dictionary<long, T> _cache = [];
+        public T this[long key] { set => save(_cache[key] = value); }
+        public bool TryGetValue(long key, [MaybeNullWhen(false)] out T value)
+        {
+            if (_cache.TryGetValue(key, out value)) return true;
+            value = load(key);
+            if (value == null) return false;
+            _cache[key] = value;
+            return true;
+        }
 
-		public T this[long key] { set => save(_cache[key] = value); }
-		public bool TryGetValue(long key, [MaybeNullWhen(false)] out T value)
-		{
-			if (_cache.TryGetValue(key, out value)) return true;
-			value = load(key);
-			if (value == null) return false;
-			_cache[key] = value;
-			return true;
-		}
-
-		internal void ClearCache() => _cache.Clear();
-		internal T? SearchCache(Predicate<T> predicate)
-		{
-			foreach (var chat in _cache.Values)
-				if (predicate(chat))
-					return chat;
-			return null;
-		}
-	}
+        public void ClearCache() => _cache.Clear();
+        public T? SearchCache(Predicate<T> predicate)
+        {
+            foreach (var chat in _cache.Values)
+                if (predicate(chat))
+                    return chat;
+            return null;
+        }
+    }
 }
 
 //TODO use bulk insert or selective update instead of full reupload of the tables

--- a/src/IBotStorage.cs
+++ b/src/IBotStorage.cs
@@ -1,0 +1,78 @@
+﻿using TL;
+using Chat = WTelegram.Types.Chat;
+using Message = WTelegram.Types.Message;
+using Update = WTelegram.Types.Update;
+using User = WTelegram.Types.User;
+
+namespace WTelegram;
+
+public interface IBotStorage : IDisposable
+{
+    public Bot.State? State { get; }
+
+    public string DataSource { get; }
+
+    public interface ISetCache<T> where T : class
+    {
+        public T this[long key] { set; }
+        public bool TryGetValue(long key, [MaybeNullWhen(false)] out T value);
+        public void ClearCache();
+        public T? SearchCache(Predicate<T> predicate);
+    }
+
+    public class SessionStore(byte[]? _data, Action<byte[]> save) : Stream
+    {
+        private int _dataLen = _data?.Length ?? 0;
+        private DateTime _lastWrite;
+        private Task? _delayedWrite;
+
+        protected override void Dispose(bool disposing) => _delayedWrite?.Wait();
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            Array.Copy(_data!, 0, buffer, offset, count);
+            return count;
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _data = buffer; _dataLen = count;
+            if (_delayedWrite != null) return;
+            var left = 1000 - (int)(DateTime.UtcNow - _lastWrite).TotalMilliseconds;
+            if (left < 0)
+            {
+                save(buffer[offset..(offset + count)]);
+                _lastWrite = DateTime.UtcNow;
+            }
+            else
+                _delayedWrite = Task.Delay(left).ContinueWith(t => { lock (this) { _delayedWrite = null; Write(_data, 0, _dataLen); } });
+        }
+
+        public override long Length => _dataLen;
+        public override long Position { get => 0; set { } }
+        public override bool CanSeek => false;
+        public override bool CanRead => true;
+        public override bool CanWrite => true;
+        public override long Seek(long offset, SeekOrigin origin) => 0;
+        public override void SetLength(long value) { }
+        public override void Flush() { }
+    }
+
+    public void Dispose();
+    public void GetTables(out ISetCache<User> users, out ISetCache<Chat> chats);
+    public Dictionary<long, UpdateManager.MBoxState> LoadMBoxStates();
+    public Stream LoadSessionState();
+    public IEnumerable<(int id, TL.Update update)> LoadTLUpdates();
+    public void SaveMBoxStates(IReadOnlyDictionary<long, UpdateManager.MBoxState> state);
+    public void SaveSessionState(byte[]? sessionData = null);
+    public void SaveTLUpdates(IEnumerable<Update> updates);
+
+    /// <summary>
+    /// Sets the state of the storage
+    /// </summary>
+    /// <remarks>
+    /// This method will only be called once internally; and the underlying object should throw an exception if an attempt is made to set it more than once
+    /// </remarks>
+    /// <param name="state"></param>
+    public void AssignBotState(Bot.State state);
+}


### PR DESCRIPTION
Added `IBotStorage` and made several small (non-breaking, or at least did my best not to break anything) changes to allow for any arbitrary storage solution to store bot states.

Added several matching constructors without modifying the signature of existing ones that take in an `IBotStorage` argument; and internally made `Database` storage implement `IBotStorage`.

Everything works as expected with both `SQLite` and `FileBotStorage` (currently implemented in `Example/ConsoleApp/FileBotStorage.cs` to not clutter up the main project unnecessarily)

During development of this PR, I modified the `.csproj` as follows:

![image](https://github.com/user-attachments/assets/2aa483b1-e148-471d-8361-08be07bcca65)

Did my best to prevent changing accesibility of members and types too much while still allowing necessary access to load and save `Bot.State`

<hr/>
My reasons for this PR are two-fold:
First, I think this library is awesome and I saw an opportunity to contribute that didn't change much of this, also I often don't like it when libraries don't provide a high degree of customization (Much like ASP.NET Identity Security Token)

Second, I once had a client who was very adamant on me saving the bot's state (before this library) as json, no database (despite a database already being provided by him for other reasons, and me telling them about SQLite)
I figured this would make it far easier to deal with such edge-cases without compromising on almost anything regarding the library