### PR TITLE
optimization methods GetChatMembersList, GetChatAdministration, GetMessagesById

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -364,3 +364,6 @@ MigrationBackup/
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
 /Examples/NativeAOT
+
+# For testing new features/optimization
+tests/

--- a/src/Bot.Methods.cs
+++ b/src/Bot.Methods.cs
@@ -21,11 +21,13 @@ public partial class Bot
 	public async Task<ChatMember[]> GetChatMemberList(ChatId chatId, int limit = 1000)
 	{
 		InputPeer chat = await InputPeerChat(chatId);
+
 		if (chat is InputPeerChannel ipc)
 		{
-			var participants = new List<ChannelParticipantBase>();
+			var participants = new List<ChannelParticipantBase>(limit);
 			InputChannelBase channel = ipc;
-			for (int offset = 0; ;)
+
+			for (int offset = 0;;)
 			{
 				var ccp = await Client.Channels_GetParticipants(channel, null, offset, limit - offset, 0);
 				ccp.UserOrChat(_collector);
@@ -33,32 +35,42 @@ public partial class Bot
 				offset += ccp.participants.Length;
 				if (offset >= ccp.count || offset >= limit || ccp.participants.Length == 0) break;
 			}
-			return await participants.Select(async p => p.ChatMember(await UserOrResolve(p.UserId))).WhenAllSequential();
+
+			return await participants.MapParticipants(this);
 		}
 		else
 		{
 			var full = await Client.Messages_GetFullChat(chat.ID);
 			full.UserOrChat(_collector);
-			if (full.full_chat is not ChatFull { participants: ChatParticipants participants })
+
+			if (full.full_chat is not ChatFull { participants: ChatParticipants cp })
 				throw new WTException($"Cannot fetch participants for chat {chatId}");
-			return await participants.participants.Select(async p => p.ChatMember(await UserOrResolve(p.UserId))).WhenAllSequential();
+
+			return await cp.participants.MapParticipants(this);
 		}
 	}
+
 
 	/// <summary>Get chat messages based on their messageIds</summary>
 	/// <remarks>⚠️ Might be limited to 100 ids per call. Fetching other bots messages with this method will result in empty messages</remarks>
 	/// <param name="chatId">The chat id or username</param>
 	/// <param name="messageIds">The message IDs to fetch. You can use <c>Enumerable.Range(startMsgId, count)</c> to get a range of messages</param>
 	/// <returns>List of messages that could be fetched</returns>
-	public async Task<List<Message>> GetMessagesById(ChatId chatId, IEnumerable<int> messageIds)
+	public async Task<List<Message>> GetMessagesById(ChatId chatId, params int[] messageIds)
 	{
+		var inputMessages = new InputMessage[messageIds.Length];
+		for (int i = 0; i < messageIds.Length; i++)
+			inputMessages[i] = messageIds[i];
+
 		var peer = await InputPeerChat(chatId);
-		var msgs = await Client.GetMessages(peer, [.. messageIds.Select(id => (InputMessage)id)]);
+		var msgs = await Client.GetMessages(peer, inputMessages);
 		msgs.UserOrChat(_collector);
-		var messages = new List<Message>();
+
+		var messages = new List<Message>(msgs.Messages.Length);
 		foreach (var msgBase in msgs.Messages)
 			if (await MakeMessage(msgBase) is { } msg)
 				messages.Add(msg);
+
 		return messages;
 	}
 
@@ -1501,19 +1513,23 @@ public partial class Bot
 	public async Task<ChatMember[]> GetChatAdministrators(ChatId chatId)
 	{
 		InputPeer chat = await InputPeerChat(chatId);
+
 		if (chat is InputPeerChannel ipc)
 		{
 			var participants = await Client.Channels_GetParticipants(ipc, new ChannelParticipantsAdmins());
 			participants.UserOrChat(_collector);
-			return await participants.participants.Select(async p => p.ChatMember(await UserOrResolve(p.UserId))).WhenAllSequential();
+			return await participants.participants.MapParticipants(this);
 		}
 		else
 		{
 			var full = await Client.Messages_GetFullChat(chat.ID);
 			full.UserOrChat(_collector);
-			if (full.full_chat is not ChatFull { participants: ChatParticipants participants })
+
+			if (full.full_chat is not ChatFull { participants: ChatParticipants cp })
 				throw new WTException($"Cannot fetch participants for chat {chatId}");
-			return await participants.participants.Where(p => p.IsAdmin).Select(async p => p.ChatMember(await UserOrResolve(p.UserId))).WhenAllSequential();
+
+			var admins = Array.FindAll(cp.participants, p => p.IsAdmin);
+			return await admins.MapParticipants(this);
 		}
 	}
 

--- a/src/BotHelpers.cs
+++ b/src/BotHelpers.cs
@@ -33,12 +33,44 @@ public static class BotHelpers
 	};
 
 	// Task.WhenAll may lead to unnecessary multiple parallel resolve of the same users/stickerset
-	internal async static Task<TResult[]> WhenAllSequential<TResult>(this IEnumerable<Task<TResult>> tasks)
+	internal static async Task<TResult[]> WhenAllSequential<TResult>(this IEnumerable<Task<TResult>> tasks)
 	{
-		var result = new List<TResult>();
+		if (tasks is ICollection<Task<TResult>> col)
+		{
+			var result = new TResult[col.Count];
+			int i = 0;
+			foreach (var task in tasks)
+				result[i++] = await task;
+			return result;
+		}
+
+		// fallback
+		var list = new List<TResult>();
 		foreach (var task in tasks)
-			result.Add(await task);
-		return [.. result];
+			list.Add(await task);
+		return list.ToArray();
+	}
+
+	internal static async Task<ChatMember[]> MapParticipants(this IReadOnlyList<TL.ChannelParticipantBase> participants, Bot bot)
+	{
+		var result = new ChatMember[participants.Count];
+		for (int i = 0; i < participants.Count; i++)
+		{
+			var p = participants[i];
+			result[i] = p.ChatMember(await bot.UserOrResolve(p.UserId));
+		}
+		return result;
+	}
+
+	internal static async Task<ChatMember[]> MapParticipants(this IReadOnlyList<TL.ChatParticipantBase> participants, Bot bot)
+	{
+		var result = new ChatMember[participants.Count];
+		for (int i = 0; i < participants.Count; i++)
+		{
+			var p = participants[i];
+			result[i] = p.ChatMember(await bot.UserOrResolve(p.UserId));
+		}
+		return result;
 	}
 
 	internal static IEnumerable<T> NotNull<T>(this IEnumerable<T?> enumerable) where T : class


### PR DESCRIPTION
Unfortunately, I don’t know what to write here, so I’ll leave the commits and benchmarks here (unfortunately, I didn’t measure the methods before optimization:( )

WTelegramBot/src/Bot.Methods.cs
- optimizing methods, linq and re/alloc reduced; GetMessagesById method now accepts params int[] insead of IEnumerable

WTelegramBot/src/BotHelpers.cs
- if tasks is ICollection, capacity will be added; Added new methods MapParticipants to minimize alloc in GetChatAdministrator, GetChatMembersList

================================================================================
Method                      Runs   Avg ms   Min ms   Max ms    Avg alloc    Total alloc
--------------------------------------------------------------------------------
GetChatMemberList              5    160,0      105      203      41,2 KB       206,1 KB
GetChatAdministrators          5    121,0       86      153      17,6 KB        88,2 KB
GetMessagesById                5    102,0       93      127      26,7 KB       133,4 KB
================================================================================


(with 2 warmup)